### PR TITLE
Fix ValidatePayload after a fresh clone

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,6 +13,11 @@
 *.yml text eol=lf
 *.ini text eol=crlf
 
+# Payload copies are SHA-256 gated by manifest.json. Keep those bytes
+# identical to the committed blobs or ValidatePayload fails after clone.
+payload/**/*.ps1 text eol=lf
+payload/**/*.ini text eol=lf
+
 *.png binary
 *.dll binary
 *.addon64 binary

--- a/manifest.json
+++ b/manifest.json
@@ -57,7 +57,7 @@
                   },
                   {
                       "path":  "Release\\ReShade.ini",
-                      "patchedSha256":  "8778D481E7E815CFC8527B267F3E8003A867E8AAE5BF92D666CD5E44CC313226",
+                      "patchedSha256":  "CCB7EFFB1EF60DA2D49F6EEDF86ADF3DF71D71EC12E23892C2DC33AC71C9023B",
                       "originalMayBeMissing":  true,
                       "runtimeMutable":  true,
                       "module":  "vr-runtime"


### PR DESCRIPTION
## Summary

`.\Patcher.ps1 -Action ValidatePayload` fails on a fresh clone. That is the first check in CONTRIBUTING.md.

- `.gitattributes` converted hashed payload `.ps1` / `.ini` files to CRLF on checkout, so their SHA-256 no longer matched `manifest.json`.
- `payload/Release/ReShade.ini` already had a stale manifest hash versus the committed blob.

This keeps those payload copies as LF and updates the `ReShade.ini` hash to `CCB7EFFB…`. After checkout, all 15 payload hashes match.

## Validation

- [x] Payload SHA-256 values match the files on disk after a fresh-style checkout
- [ ] Native add-on compiled from a clean dependency directory
- [ ] Changed Lua files were syntax-checked
- [ ] Guarded install and verify passed
- [ ] Uninstall/restore passed
- [ ] Quest/OpenXR hardware testing is described below
- [x] No credentials, personal data, logs, backups, or generated root installer were committed

This is a checkout/hash-gating fix only. No native, Lua, or installer behavior change.

## Hardware testing

Not applicable. No renderer, input, or payload content bytes were changed beyond line-ending policy for hashed text files.